### PR TITLE
Add Silent option to AppCenterDistributeReleaseSettings

### DIFF
--- a/src/Cake.AppCenter/Distribute/Release/AppCenterDistributeReleaseSettings.cs
+++ b/src/Cake.AppCenter/Distribute/Release/AppCenterDistributeReleaseSettings.cs
@@ -75,5 +75,10 @@ namespace Cake.AppCenter
 		/// Display extra output for debugging
 		/// </summary>
 		public bool? Debug { get; set; }
+		/// <summary>
+		/// --silent 
+		/// Do not notify testers of this release
+		/// </summary>
+		public bool? Silent { get; set; }
 	}
 }


### PR DESCRIPTION
Silent is not a same as Quiet. Silent means " Do not notify testers of this release"

## Description
Adds --silent option found from cli to AppCenterDistributeReleaseSettings

I am assuming documentation is auto generated from code comments.

## Motivation and Context
Silent is very nice to have when you are doing hourly CI/CD.

## How Has This Been Tested?
No. I assume it works like other optional bool parameters.

## Screenshots (if appropriate):

## Types of changes
- [x] New feature (non-breaking change which adds functionality)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
