### PR TITLE
Add ability to upload to a store

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -132,7 +132,7 @@ DocProject/Help/Html2
 DocProject/Help/html
 
 # Click-Once directory
-publish/
+./publish/
 
 # Publish Web Output
 *.[Pp]ublish.xml

--- a/src/Cake.AppCenter/Distribute/Releases/Stores/List/AppCenter.Alias.DistributeStoresList.cs
+++ b/src/Cake.AppCenter/Distribute/Releases/Stores/List/AppCenter.Alias.DistributeStoresList.cs
@@ -1,0 +1,47 @@
+using Cake.Core;
+using Cake.Core.Annotations;
+using System;
+using System.Collections.Generic;
+
+namespace Cake.AppCenter
+{
+    partial class AppCenterAliases
+    {
+        /// <summary>
+        /// Lists all stores of the app.
+        /// </summary>
+        /// <param name="context">The context.</param>
+        /// <param name="settings">The settings.</param>
+        [CakeMethodAlias]
+        public static void AppCenterDistributeStoresList(this ICakeContext context, AppCenterDistributeStoresListSettings settings)
+        {
+            if (context == null)
+            {
+                throw new ArgumentNullException("context");
+            }
+
+            var arguments = new string[0];
+            var runner = new GenericRunner<AppCenterDistributeStoresListSettings>(context.FileSystem, context.Environment, context.ProcessRunner, context.Tools);
+            runner.Run("distribute stores list", settings ?? new AppCenterDistributeStoresListSettings(), arguments);
+        }
+
+        /// <summary>
+        /// Lists all stores of the app.
+        /// </summary>
+        /// <param name="context">The context.</param>
+        /// <param name="settings">The settings.</param>
+        /// <returns>Output lines.</returns>
+        [CakeMethodAlias]
+        public static IEnumerable<string> AppCenterDistributeStoresListWithResult(this ICakeContext context, AppCenterDistributeStoresListSettings settings)
+        {
+            if (context == null)
+            {
+                throw new ArgumentNullException("context");
+            }
+
+            var arguments = new string[0];
+            var runner = new GenericRunner<AppCenterDistributeStoresListSettings >(context.FileSystem, context.Environment, context.ProcessRunner, context.Tools);
+            return runner.RunWithResult("distribute stores list", settings ?? new AppCenterDistributeStoresListSettings(), arguments);
+        }
+    }
+}

--- a/src/Cake.AppCenter/Distribute/Releases/Stores/List/AppCenterDistributesStoresListSettings.cs
+++ b/src/Cake.AppCenter/Distribute/Releases/Stores/List/AppCenterDistributesStoresListSettings.cs
@@ -1,0 +1,66 @@
+using System;
+using System.Runtime.CompilerServices;
+
+namespace Cake.AppCenter
+{
+    /// <summary>
+    /// Settings for appcenter distribute stores list.
+    /// </summary>
+    [CompilerGenerated]
+    public sealed class AppCenterDistributeStoresListSettings : AutoToolSettings
+    {
+        /// <summary>
+        /// -a|--app &lt;arg&gt;
+        /// Specify app in the &lt;ownerName&gt;/&lt;appName&gt; format
+        /// </summary>
+        public string App { get; set; }
+
+        /// <summary>
+        /// --disable-telemetry
+        /// Disable telemetry for this command
+        /// </summary>
+        public bool? DisableTelemetry { get; set; }
+
+        /// <summary>
+        /// -v|--version
+        /// Display appcenter version
+        /// </summary>
+        public bool? Version { get; set; }
+
+        /// <summary>
+        /// --quiet
+        /// Auto-confirm any prompts without waiting for input
+        /// </summary>
+        public bool? Quiet { get; set; }
+
+        /// <summary>
+        /// -h|--help
+        /// Display help for current command
+        /// </summary>
+        public bool? Help { get; set; }
+
+        /// <summary>
+        /// --env &lt;arg&gt;
+        /// Environment when using API token
+        /// </summary>
+        public string Env { get; set; }
+
+        /// <summary>
+        /// --token &lt;arg&gt;
+        /// API token
+        /// </summary>
+        public string Token { get; set; }
+
+        /// <summary>
+        /// --output &lt;arg&gt;
+        /// Output format: json
+        /// </summary>
+        public string Output { get; set; }
+
+        /// <summary>
+        /// --debug
+        /// Display extra output for debugging
+        /// </summary>
+        public bool? Debug { get; set; }
+    }
+}

--- a/src/Cake.AppCenter/Distribute/Releases/Stores/Publish/AppCenter.Alias.DistributeStoresPublish.cs
+++ b/src/Cake.AppCenter/Distribute/Releases/Stores/Publish/AppCenter.Alias.DistributeStoresPublish.cs
@@ -1,0 +1,47 @@
+using Cake.Core;
+using Cake.Core.Annotations;
+using System;
+using System.Collections.Generic;
+
+namespace Cake.AppCenter
+{
+    partial class AppCenterAliases
+    {
+        /// <summary>
+        /// Publish an app file to a store.
+        /// </summary>
+        /// <param name="context">The context.</param>
+        /// <param name="settings">The settings.</param>
+        [CakeMethodAlias]
+        public static void AppCenterDistributeStoresPublish(this ICakeContext context, AppCenterDistributeStoresPublishSettings settings)
+        {
+            if (context == null)
+            {
+                throw new ArgumentNullException("context");
+            }
+
+            var arguments = new string[0];
+            var runner = new GenericRunner<AppCenterDistributeStoresPublishSettings>(context.FileSystem, context.Environment, context.ProcessRunner, context.Tools);
+            runner.Run("distribute stores publish", settings ?? new AppCenterDistributeStoresPublishSettings(), arguments);
+        }
+
+        /// <summary>
+        /// Publish an app file to a store.
+        /// </summary>
+        /// <param name="context">The context.</param>
+        /// <param name="settings">The settings.</param>
+        /// <returns>Output lines.</returns>
+        [CakeMethodAlias]
+        public static IEnumerable<string> AppCenterDistributeStoresPublishWithResult(this ICakeContext context, AppCenterDistributeStoresPublishSettings settings)
+        {
+            if (context == null)
+            {
+                throw new ArgumentNullException("context");
+            }
+
+            var arguments = new string[0];
+            var runner = new GenericRunner<AppCenterDistributeStoresPublishSettings>(context.FileSystem, context.Environment, context.ProcessRunner, context.Tools);
+            return runner.RunWithResult("distribute stores publish", settings ?? new AppCenterDistributeStoresPublishSettings(), arguments);
+        }
+    }
+}

--- a/src/Cake.AppCenter/Distribute/Releases/Stores/Publish/AppCenterDistributeStoresPublishSettings.cs
+++ b/src/Cake.AppCenter/Distribute/Releases/Stores/Publish/AppCenterDistributeStoresPublishSettings.cs
@@ -1,0 +1,90 @@
+using System;
+using System.Runtime.CompilerServices;
+
+namespace Cake.AppCenter
+{
+    /// <summary>
+    /// Settings for appcenter distribute stores publish.
+    /// </summary>
+    [CompilerGenerated]
+    public sealed class AppCenterDistributeStoresPublishSettings : AutoToolSettings
+    {
+        /// <summary>
+        /// -s|--store &lt;arg&gt;
+        /// Store name
+        /// </summary>
+        public string Store { get; set; }
+
+        /// <summary>
+        /// -f|--file &lt;arg&gt;
+        /// Path to binary file
+        /// </summary>
+        public string File { get; set; }
+
+        /// <summary>
+        /// -R|--release-notes-file &lt;arg&gt;
+        /// Path to release notes file
+        /// </summary>
+        public string ReleaseNotesFile { get; set; }
+
+        /// <summary>
+        /// -r|--release-notes &lt;arg&gt;
+        /// Release notes text
+        /// </summary>
+        public string ReleaseNotes { get; set; }
+
+        /// <summary>
+        /// -a|--app &lt;arg&gt;
+        /// Specify app in the &lt;ownerName&gt;/&lt;appName&gt; format
+        /// </summary>
+        public string App { get; set; }
+
+        /// <summary>
+        /// --disable-telemetry
+        /// Disable telemetry for this command
+        /// </summary>
+        public bool? DisableTelemetry { get; set; }
+
+        /// <summary>
+        /// -v|--version
+        /// Display appcenter version
+        /// </summary>
+        public bool? Version { get; set; }
+
+        /// <summary>
+        /// --quiet
+        /// Auto-confirm any prompts without waiting for input
+        /// </summary>
+        public bool? Quiet { get; set; }
+
+        /// <summary>
+        /// -h|--help
+        /// Display help for current command
+        /// </summary>
+        public bool? Help { get; set; }
+
+        /// <summary>
+        /// --env &lt;arg&gt;
+        /// Environment when using API token
+        /// </summary>
+        public string Env { get; set; }
+
+        /// <summary>
+        /// --token &lt;arg&gt;
+        /// API token
+        /// </summary>
+        public string Token { get; set; }
+
+        /// <summary>
+        /// --output &lt;arg&gt;
+        /// Output format: json
+        /// </summary>
+        public string Output { get; set; }
+
+        /// <summary>
+        /// --debug
+        /// Display extra output for debugging
+        /// </summary>
+        public bool? Debug { get; set; }
+    }
+}


### PR DESCRIPTION
## Description
Adds new aliases for store uploads via AppCenter.

## Related Issue
https://github.com/cake-contrib/Cake.AppCenter/issues/18

## Motivation and Context
Adds support for App Center's store upload functionality.

## How Has This Been Tested?
I'm actually not sure how testing is normally done for this repo; I'm happy to follow any required test steps.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

I tried to run the tests in VS for Mac, but they did not complete.